### PR TITLE
Use relative path for CSV

### DIFF
--- a/src/routes/typebot.py
+++ b/src/routes/typebot.py
@@ -10,7 +10,9 @@ typebot_bp = Blueprint('typebot', __name__)
 def get_cardapio_completo():
     """Retorna o cardápio completo"""
     try:
-        df = pd.read_csv(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "cardapio_exemplo.csv"))
+        df = pd.read_csv(
+            os.path.join(os.path.dirname(__file__), "..", "..", "cardapio_exemplo.csv")
+        )
         cardapio = "🍽️ *CARDÁPIO COMPLETO* 🍽️\n\n"
         
         for index, row in df.iterrows():
@@ -27,7 +29,9 @@ def get_cardapio_completo():
 def get_ingredientes(prato_nome):
     """Retorna os ingredientes de um prato específico"""
     try:
-        df = pd.read_csv('cardapio_exemplo.csv')
+        df = pd.read_csv(
+            os.path.join(os.path.dirname(__file__), "..", "..", "cardapio_exemplo.csv")
+        )
         prato = df[df['prato'].str.contains(prato_nome, case=False, na=False)]
         
         if not prato.empty:
@@ -48,7 +52,9 @@ def get_ingredientes(prato_nome):
 def get_modo_preparo(prato_nome):
     """Retorna o modo de preparo de um prato específico"""
     try:
-        df = pd.read_csv('cardapio_exemplo.csv')
+        df = pd.read_csv(
+            os.path.join(os.path.dirname(__file__), "..", "..", "cardapio_exemplo.csv")
+        )
         prato = df[df['prato'].str.contains(prato_nome, case=False, na=False)]
         
         if not prato.empty:

--- a/src/routes/whatsapp.py
+++ b/src/routes/whatsapp.py
@@ -10,7 +10,9 @@ whatsapp_bp = Blueprint('whatsapp', __name__)
 def get_cardapio_completo():
     """Retorna o cardápio completo"""
     try:
-        df = pd.read_csv(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "cardapio_exemplo.csv"))
+        df = pd.read_csv(
+            os.path.join(os.path.dirname(__file__), "..", "..", "cardapio_exemplo.csv")
+        )
         cardapio = "🍽️ *CARDÁPIO COMPLETO* 🍽️\n\n"
         
         for index, row in df.iterrows():
@@ -27,7 +29,9 @@ def get_cardapio_completo():
 def get_ingredientes(prato_nome):
     """Retorna os ingredientes de um prato específico"""
     try:
-        df = pd.read_csv('cardapio_exemplo.csv')
+        df = pd.read_csv(
+            os.path.join(os.path.dirname(__file__), "..", "..", "cardapio_exemplo.csv")
+        )
         prato = df[df['prato'].str.contains(prato_nome, case=False, na=False)]
         
         if not prato.empty:
@@ -48,7 +52,9 @@ def get_ingredientes(prato_nome):
 def get_modo_preparo(prato_nome):
     """Retorna o modo de preparo de um prato específico"""
     try:
-        df = pd.read_csv('cardapio_exemplo.csv')
+        df = pd.read_csv(
+            os.path.join(os.path.dirname(__file__), "..", "..", "cardapio_exemplo.csv")
+        )
         prato = df[df['prato'].str.contains(prato_nome, case=False, na=False)]
         
         if not prato.empty:


### PR DESCRIPTION
## Summary
- ensure WhatsApp and Typebot routes load `cardapio_exemplo.csv` using a path relative to each module

## Testing
- `python - <<'PY'
import os, csv
path = os.path.join(os.path.dirname(os.path.abspath('src/routes/whatsapp.py')), '..', '..', 'cardapio_exemplo.csv')
print('Path exists?', os.path.exists(path))
with open(path, newline='', encoding='utf-8') as f:
    reader = csv.reader(f)
    for i, row in enumerate(reader):
        if i<3:
            print(row)
PY`

Unable to run full application tests due to missing dependencies in the environment.

------
https://chatgpt.com/codex/tasks/task_e_68aa813c1094832397d893f501c7d3b5