### PR TITLE
Add timeout handling for Typebot requests

### DIFF
--- a/src/routes/typebot.py
+++ b/src/routes/typebot.py
@@ -29,8 +29,12 @@ def send_to_typebot(session_id, message):
             f"{typebot_url}/api/v1/{typebot_id}/message",
             json=payload,
             headers={"Content-Type": "application/json"},
+            timeout=10,
         )
         response.raise_for_status()
         return response.json()
+    except requests.Timeout as e:
+        print(f"Timeout error while contacting Typebot: {e}")
+        return {"error": "Typebot request timed out"}
     except Exception as e:
         return {"error": str(e)}


### PR DESCRIPTION
## Summary
- add 10-second timeout to Typebot request
- log and handle requests.Timeout errors

## Testing
- `python -m py_compile src/routes/typebot.py src/routes/whatsapp.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa8624d77483238ab85ddf5f912c82