### PR TITLE
Remove unused imports in route modules

### DIFF
--- a/src/routes/typebot.py
+++ b/src/routes/typebot.py
@@ -1,15 +1,6 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint
 import requests
 import os
-import json
-from datetime import datetime
-
-from utils.cardapio import (
-    get_cardapio_completo,
-    get_ingredientes,
-    get_modo_preparo,
-)
-
 
 typebot_bp = Blueprint('typebot', __name__)
 

--- a/src/routes/whatsapp.py
+++ b/src/routes/whatsapp.py
@@ -1,15 +1,4 @@
-from flask import Blueprint, request, jsonify
-import requests
-import os
-import json
-from datetime import datetime
-
-from utils.cardapio import (
-    get_cardapio_completo,
-    get_ingredientes,
-    get_modo_preparo,
-)
-
+from flask import Blueprint
 
 whatsapp_bp = Blueprint('whatsapp', __name__)
 


### PR DESCRIPTION
## Summary
- clean up unused imports in WhatsApp and Typebot routes

## Testing
- `python - <<'PY'
import ast, sys
files = ['src/routes/whatsapp.py','src/routes/typebot.py']
for path in files:
    with open(path, 'r') as f:
        tree = ast.parse(f.read(), filename=path)
    imported = set()
    for node in ast.walk(tree):
        if isinstance(node, ast.Import):
            for alias in node.names:
                imported.add(alias.asname or alias.name.split('.')[0])
        elif isinstance(node, ast.ImportFrom):
            for alias in node.names:
                imported.add(alias.asname or alias.name)
    used = set()
    class ImportUsageVisitor(ast.NodeVisitor):
        def visit_Name(self, node):
            used.add(node.id)
    ImportUsageVisitor().visit(tree)
    unused = imported - used
    if unused:
        print(f"{path}: unused imports: {', '.join(sorted(unused))}")
    else:
        print(f"{path}: no unused imports")
PY`


------
https://chatgpt.com/codex/tasks/task_e_68aa874279f883239838e7781de79663