### PR TITLE
Remove unused jsonify import

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 import os
-from flask import Flask, jsonify
+from flask import Flask
 from flask_cors import CORS
 from routes.whatsapp import whatsapp_bp
 from routes.typebot import typebot_bp


### PR DESCRIPTION
## Summary
- remove unused `jsonify` from Flask import

## Testing
- `python -m py_compile src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68aa955b86788323915a3373e631263b